### PR TITLE
remove :uneeded

### DIFF
--- a/stripe.rb
+++ b/stripe.rb
@@ -6,7 +6,6 @@ class Stripe < Formula
   desc "Stripe CLI utility"
   homepage "https://stripe.com"
   version "1.7.6"
-  bottle :unneeded
   depends_on :macos
 
   on_macos do


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the stripe/stripe-cli tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/stripe/homebrew-stripe-cli/stripe.rb:9
```